### PR TITLE
Upgrade `google_sign_in` and `http` to resolve version conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.2+2
+
+* Update `google_sign_in` and `http` dependencies
+
 # 0.2.2+1
 * Add pubspec.lock to .gitignore
 * Update dependencies

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: google_sign_in_dartio
 description: Flutter package for Google Sign-In built in dart and support both Mobile and Desktop environments.
-version: 0.2.2+1
+version: 0.2.2+2
 homepage: https://github.com/long1eu/google_sign_in_dart
 commit: 89794a635a5efad6705e3d7ccc29e8139318d947
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  google_sign_in: ^6.0.1
+  google_sign_in: ^6.1.6
   google_sign_in_platform_interface: ^2.3.1
   shared_preferences: ^2.0.18
   shared_preferences_foundation: ^2.1.4
@@ -19,7 +19,7 @@ dependencies:
   url_launcher: ^6.1.10
   url_launcher_macos: ^3.0.3
   crypto: ^3.0.2
-  http: ^0.13.5
+  http: ^1.1.2
   html_unescape: ^2.0.0
 
 dev_dependencies:


### PR DESCRIPTION
Many packages require `http` +1.0. Therefore, we should also upgrade this package to `http` +1.0 to resolve version conflicts like #19.

Until this PR is merged, you can use in your `pubspec.yaml` as a workaround:

```yaml
google_sign_in_dartio:
    git:
      url: https://github.com/nilsreichardt/google_sign_in_dart
      ref: aa8dd1d7a43516b0815a92f0b5a470452ebb2efc
```

Fixes #19 